### PR TITLE
Allow loading any LlamaForCausalLM model

### DIFF
--- a/medalpaca/inferer.py
+++ b/medalpaca/inferer.py
@@ -83,7 +83,7 @@ class Inferer:
         else: 
             load_model = AutoModelForCausalLM
             
-        model = LlamaForCausalLM.from_pretrained(
+        model = load_model.from_pretrained(
             base_model,
             load_in_8bit=load_in_8bit,
             torch_dtype=torch_dtype,


### PR DESCRIPTION
Allow loading any LlamaForCausalLM model. 
Looks like this was the original intent, since load_model isn't in use in the current code.

Thanks.