### PR TITLE
Fix the logic of skipping in eval_usmle

### DIFF
--- a/eval/eval_usmle.py
+++ b/eval/eval_usmle.py
@@ -151,7 +151,7 @@ def main(
         pbar = tqdm(step)
         pbar.set_description_str(f"Evaluating USMLE Step {step_idx}")
         for i, question in enumerate(pbar): 
-            if skip_if_exists and i <= len(answers):
+            if skip_if_exists and (i+1) <= len(answers):
                 continue
             for j in range(ntries): 
                 response = model(


### PR DESCRIPTION
The current code would skip the first instance of each of the USMLE step questions.
I have fixed the code to consider all the questions and not skip the first question.

The fix could also be the following:
`if skip_if_exists and question["no"] <= len(answers):`